### PR TITLE
fix(cache): handle missing cache key gracefully

### DIFF
--- a/Service/CacheMaintenanceService.php
+++ b/Service/CacheMaintenanceService.php
@@ -173,6 +173,10 @@ class CacheMaintenanceService
         }
 
         $serializedData = $this->cache->load($key);
+        if ($serializedData === false) {
+            return false;
+        }
+        
         return $this->serializer->unserialize($serializedData);
     }
 


### PR DESCRIPTION
Added a check to ensure that unserialization is not attempted when the cache key does not exist. This prevents potential errors caused by invalid or missing data.